### PR TITLE
perf: enable experimental faster mode and add @docusaurus/faster (~3.5 -> ~2.5 seconds)

### DIFF
--- a/docusaurus.config.js
+++ b/docusaurus.config.js
@@ -68,6 +68,11 @@ const config = {
       }),
     ],
   ],
+  future: {
+    experimental_faster: true,
+    v4: true,
+  },
+
   themeConfig:
     /** @type {import('@docusaurus/preset-classic').ThemeConfig} */
     ({

--- a/package.json
+++ b/package.json
@@ -15,6 +15,7 @@
   },
   "dependencies": {
     "@docusaurus/core": "3.9.2",
+    "@docusaurus/faster": "3.9.2",
     "@docusaurus/preset-classic": "3.9.2",
     "@docusaurus/theme-live-codeblock": "3.9.2",
     "@mdx-js/react": "^3.0.0",


### PR DESCRIPTION
# Description 

- See #31 . 
- https://docusaurus.io/blog/releases/3.8#docusaurus-faster

## before 

 ember-react-cheatsheet % time npm run build

> ember-react-cheatsheet@0.0.0 build
> docusaurus build

[INFO] [en] Creating an optimized production build...

✔ Client
  Compiled successfully in 689.16ms

✔ Server
  


● Client █████████████████████████ cache (99%) shutdown IdleFileCachePlugin
 stored

✔ Server
  

[SUCCESS] Generated static files in "build".
[INFO] Use `npm run serve` command to test your build locally.
npm run build  3.55s user 0.67s system 111% cpu 3.783 total

## after 

time npm run build

> ember-react-cheatsheet@0.0.0 build
> docusaurus build

[INFO] [en] Creating an optimized production build...
● Client ██████████████████████████████████████████████████ (100%) emitting after emit                         
● Server ██████████████████████████████████████████████████ (100%) emitting after emit                         [SUCCESS] Generated static files in "build".
[INFO] Use `npm run serve` command to test your build locally.
npm run build  2.46s user 0.96s system 128% cpu 2.659 total